### PR TITLE
Fix bool pInvokes

### DIFF
--- a/rcldotnet/ActionClient.cs
+++ b/rcldotnet/ActionClient.cs
@@ -49,7 +49,7 @@ namespace ROS2
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate RCLRet NativeRCLActionServerIsAvailableType(
-            SafeNodeHandle nodeHandle, SafeActionClientHandle clientHandle, out bool isAvailable);
+            SafeNodeHandle nodeHandle, SafeActionClientHandle clientHandle, out int isAvailable);
 
         internal static NativeRCLActionServerIsAvailableType native_rcl_action_server_is_available = null;
 
@@ -156,10 +156,10 @@ namespace ROS2
 
         public override bool ServerIsReady()
         {
-            RCLRet ret = ActionClientDelegates.native_rcl_action_server_is_available(_node.Handle, Handle, out var serverIsReady);
+            RCLRet ret = ActionClientDelegates.native_rcl_action_server_is_available(_node.Handle, Handle, out int serverIsReady);
             RCLExceptionHelper.CheckReturnValue(ret, $"{nameof(ActionClientDelegates.native_rcl_action_server_is_available)}() failed.");
 
-            return serverIsReady;
+            return serverIsReady != 0;
         }
 
         public Task<ActionClientGoalHandle<TAction, TGoal, TResult, TFeedback>> SendGoalAsync(TGoal goal)

--- a/rcldotnet/ActionServerGoalHandle.cs
+++ b/rcldotnet/ActionServerGoalHandle.cs
@@ -87,8 +87,8 @@ namespace ROS2
         {
             get
             {
-                bool isActive = RCLdotnetDelegates.native_rcl_action_goal_handle_is_active(Handle);
-                return isActive;
+                int isActive = RCLdotnetDelegates.native_rcl_action_goal_handle_is_active(Handle);
+                return isActive != 0;
             }
         }
 

--- a/rcldotnet/Client.cs
+++ b/rcldotnet/Client.cs
@@ -33,7 +33,7 @@ namespace ROS2
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate RCLRet NativeRCLServiceServerIsAvailableType(
-            SafeNodeHandle nodeHandle, SafeClientHandle clientHandle, out bool isAvailable);
+            SafeNodeHandle nodeHandle, SafeClientHandle clientHandle, out int isAvailable);
 
         internal static NativeRCLServiceServerIsAvailableType native_rcl_service_server_is_available = null;
 
@@ -95,10 +95,10 @@ namespace ROS2
 
         public bool ServiceIsReady()
         {
-            RCLRet ret = ClientDelegates.native_rcl_service_server_is_available(_node.Handle, Handle, out var serviceIsReady);
+            RCLRet ret = ClientDelegates.native_rcl_service_server_is_available(_node.Handle, Handle, out int serviceIsReady);
             RCLExceptionHelper.CheckReturnValue(ret, $"{nameof(ClientDelegates.native_rcl_service_server_is_available)}() failed.");
 
-            return serviceIsReady;
+            return serviceIsReady != 0;
         }
 
         public Task<TResponse> SendRequestAsync(TRequest request)

--- a/rcldotnet/RCLdotnet.cs
+++ b/rcldotnet/RCLdotnet.cs
@@ -42,7 +42,7 @@ namespace ROS2
         internal static NativeRCLResetErrorType native_rcl_reset_error = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLOkType();
+        internal delegate int NativeRCLOkType();
 
         internal static NativeRCLOkType native_rcl_ok = null;
 
@@ -119,22 +119,22 @@ namespace ROS2
         internal static NativeRCLWaitType native_rcl_wait = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLWaitSetSubscriptionReady(SafeWaitSetHandle waitSetHandle, int index);
+        internal delegate int NativeRCLWaitSetSubscriptionReady(SafeWaitSetHandle waitSetHandle, int index);
 
         internal static NativeRCLWaitSetSubscriptionReady native_rcl_wait_set_subscription_ready = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLWaitSetClientReady(SafeWaitSetHandle waitSetHandle, int index);
+        internal delegate int NativeRCLWaitSetClientReady(SafeWaitSetHandle waitSetHandle, int index);
 
         internal static NativeRCLWaitSetClientReady native_rcl_wait_set_client_ready = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLWaitSetServiceReady(SafeWaitSetHandle waitSetHandle, int index);
+        internal delegate int NativeRCLWaitSetServiceReady(SafeWaitSetHandle waitSetHandle, int index);
 
         internal static NativeRCLWaitSetServiceReady native_rcl_wait_set_service_ready = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLWaitSetGuardConditionReady(SafeWaitSetHandle waitSetHandle, int index);
+        internal delegate int NativeRCLWaitSetGuardConditionReady(SafeWaitSetHandle waitSetHandle, int index);
 
         internal static NativeRCLWaitSetGuardConditionReady native_rcl_wait_set_guard_condition_ready = null;
 
@@ -188,7 +188,7 @@ namespace ROS2
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate RCLRet NativeRCLActionClientWaitSetGetEntitiesReadyType(
-            SafeWaitSetHandle waitSetHandle, SafeActionClientHandle actionClientHandle, out bool isFeedbackReady, out bool isStatusReady, out bool isGoalResponseReady, out bool isCancelResponseReady, out bool isResultResponseReady);
+            SafeWaitSetHandle waitSetHandle, SafeActionClientHandle actionClientHandle, out int isFeedbackReady, out int isStatusReady, out int isGoalResponseReady, out int isCancelResponseReady, out int isResultResponseReady);
 
         internal static NativeRCLActionClientWaitSetGetEntitiesReadyType native_rcl_action_client_wait_set_get_entities_ready = null;
 
@@ -206,7 +206,7 @@ namespace ROS2
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate RCLRet NativeRCLActionServerWaitSetGetEntitiesReadyType(
-                SafeWaitSetHandle waitSetHandle, SafeActionServerHandle actionServerHandle, out bool isGoalRequestReady, out bool isCancelRequestReady, out bool isResultRequestReady, out bool isGoalExpired);
+                SafeWaitSetHandle waitSetHandle, SafeActionServerHandle actionServerHandle, out int isGoalRequestReady, out int isCancelRequestReady, out int isResultRequestReady, out int isGoalExpired);
 
         internal static NativeRCLActionServerWaitSetGetEntitiesReadyType native_rcl_action_server_wait_set_get_entities_ready = null;
 
@@ -319,7 +319,7 @@ namespace ROS2
         internal static NativeRCLActionExpireGoalsType native_rcl_action_expire_goals = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool NativeRCLActionGoalHandleIsActiveType(SafeActionGoalHandle actionGoalHandleHandle);
+        internal delegate int NativeRCLActionGoalHandleIsActiveType(SafeActionGoalHandle actionGoalHandleHandle);
         internal static NativeRCLActionGoalHandleIsActiveType native_rcl_action_goal_handle_is_active = null;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -670,7 +670,7 @@ namespace ROS2
 
         public static bool Ok()
         {
-            return RCLdotnetDelegates.native_rcl_ok();
+            return RCLdotnetDelegates.native_rcl_ok() != 0;
         }
 
         public static Node CreateNode(string nodeName)
@@ -1146,7 +1146,7 @@ namespace ROS2
                 int subscriptionIndex = 0;
                 foreach (Subscription subscription in node.Subscriptions)
                 {
-                    if (RCLdotnetDelegates.native_rcl_wait_set_subscription_ready(waitSetHandle, subscriptionIndex))
+                    if (RCLdotnetDelegates.native_rcl_wait_set_subscription_ready(waitSetHandle, subscriptionIndex) != 0)
                     {
                         IRosMessage message = subscription.CreateMessage();
                         bool result = Take(subscription, message);
@@ -1165,7 +1165,7 @@ namespace ROS2
                     int serviceIndex = 0;
                     foreach (var service in node.Services)
                     {
-                        if (RCLdotnetDelegates.native_rcl_wait_set_service_ready(waitSetHandle, serviceIndex))
+                        if (RCLdotnetDelegates.native_rcl_wait_set_service_ready(waitSetHandle, serviceIndex) != 0)
                         {
                             var request = service.CreateRequest();
                             var response = service.CreateResponse();
@@ -1185,7 +1185,7 @@ namespace ROS2
                     int clientIndex = 0;
                     foreach (var client in node.Clients)
                     {
-                        if (RCLdotnetDelegates.native_rcl_wait_set_client_ready(waitSetHandle, clientIndex))
+                        if (RCLdotnetDelegates.native_rcl_wait_set_client_ready(waitSetHandle, clientIndex) != 0)
                         {
                             var response = client.CreateResponse();
 
@@ -1205,18 +1205,18 @@ namespace ROS2
                         RCLRet ret = RCLdotnetDelegates.native_rcl_action_client_wait_set_get_entities_ready(
                             waitSetHandle,
                             actionClient.Handle,
-                            out bool isFeedbackReady,
-                            out bool isStatusReady,
-                            out bool isGoalResponseReady,
-                            out bool isCancelResponseReady,
-                            out bool isResultResponseReady);
+                            out int isFeedbackReady,
+                            out int isStatusReady,
+                            out int isGoalResponseReady,
+                            out int isCancelResponseReady,
+                            out int isResultResponseReady);
 
                         RCLExceptionHelper.CheckReturnValue(ret, $"{nameof(RCLdotnetDelegates.native_rcl_action_client_wait_set_get_entities_ready)}() failed.");
 
                         // Check isGoalResponseReady so that a new goalHandle is
                         // already created if the status or feedback for the new
                         // goal is received.
-                        if (isGoalResponseReady)
+                        if (isGoalResponseReady != 0)
                         {
                             var goalResponse = actionClient.CreateSendGoalResponse();
 
@@ -1231,7 +1231,7 @@ namespace ROS2
                         // Check isStatusReady before isFeedbackReady so that
                         // the feedback callback already has the newest status
                         // information if updates are received at the same time.
-                        if (isStatusReady)
+                        if (isStatusReady != 0)
                         {
                             var statusMessage = new GoalStatusArray();
 
@@ -1242,7 +1242,7 @@ namespace ROS2
                             }
                         }
 
-                        if (isFeedbackReady)
+                        if (isFeedbackReady != 0)
                         {
                             var feedbackMessage = actionClient.CreateFeedbackMessage();
 
@@ -1253,7 +1253,7 @@ namespace ROS2
                             }
                         }
 
-                        if (isCancelResponseReady)
+                        if (isCancelResponseReady != 0)
                         {
                             var cancelResponse = new CancelGoal_Response();
 
@@ -1265,7 +1265,7 @@ namespace ROS2
                             }
                         }
 
-                        if (isResultResponseReady)
+                        if (isResultResponseReady != 0)
                         {
                             var resultResponse = actionClient.CreateGetResultResponse();
 
@@ -1283,14 +1283,14 @@ namespace ROS2
                         RCLRet ret = RCLdotnetDelegates.native_rcl_action_server_wait_set_get_entities_ready(
                             waitSetHandle,
                             actionServer.Handle,
-                            out bool isGoalRequestReady,
-                            out bool isCancelRequestReady,
-                            out bool isResultRequestReady,
-                            out bool isGoalExpired);
+                            out int isGoalRequestReady,
+                            out int isCancelRequestReady,
+                            out int isResultRequestReady,
+                            out int isGoalExpired);
 
                         RCLExceptionHelper.CheckReturnValue(ret, $"{nameof(RCLdotnetDelegates.native_rcl_action_server_wait_set_get_entities_ready)}() failed.");
 
-                        if (isGoalRequestReady)
+                        if (isGoalRequestReady != 0)
                         {
                             var goalRequest = actionServer.CreateSendGoalRequest();
 
@@ -1301,7 +1301,7 @@ namespace ROS2
                             }
                         }
 
-                        if (isCancelRequestReady)
+                        if (isCancelRequestReady != 0)
                         {
                             var cancelRequest = new CancelGoal_Request();
 
@@ -1312,7 +1312,7 @@ namespace ROS2
                             }
                         }
 
-                        if (isResultRequestReady)
+                        if (isResultRequestReady != 0)
                         {
                             var resultRequest = actionServer.CreateGetResultRequest();
 
@@ -1327,7 +1327,7 @@ namespace ROS2
                             }
                         }
 
-                        if (isGoalExpired)
+                        if (isGoalExpired != 0)
                         {
                             actionServer.HandleGoalExpired();
                         }
@@ -1337,7 +1337,7 @@ namespace ROS2
                 int guardConditionIndex = 0;
                 foreach (GuardCondition guardCondition in node.GuardConditions)
                 {
-                    if (RCLdotnetDelegates.native_rcl_wait_set_guard_condition_ready(waitSetHandle, guardConditionIndex))
+                    if (RCLdotnetDelegates.native_rcl_wait_set_guard_condition_ready(waitSetHandle, guardConditionIndex) != 0)
                     {
                         guardCondition.TriggerCallback();
                     }

--- a/rcldotnet/rcldotnet.c
+++ b/rcldotnet/rcldotnet.c
@@ -68,7 +68,10 @@ void native_rcl_reset_error(void) {
   rcl_reset_error();
 }
 
-bool native_rcl_ok() { return rcl_context_is_valid(&context); }
+int32_t native_rcl_ok() {
+  bool result = rcl_context_is_valid(&context);
+  return result ? 1 : 0;
+}
 
 int32_t native_rcl_create_node_handle(void **node_handle, const char *name, const char *namespace) {
   rcl_node_t *node = (rcl_node_t *)malloc(sizeof(rcl_node_t));
@@ -271,7 +274,7 @@ int32_t native_rcl_wait(void *wait_set_handle, int64_t timeout) {
   return ret;
 }
 
-bool native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index) {
+int32_t native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
 
   if (index >= wait_set->size_of_subscriptions)
@@ -279,10 +282,11 @@ bool native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index
     return false;
   }
 
-  return wait_set->subscriptions[index] != NULL;
+  bool result = wait_set->subscriptions[index] != NULL;
+  return result ? 1 : 0;
 }
 
-bool native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index) {
+int32_t native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
 
   if (index >= wait_set->size_of_clients)
@@ -290,10 +294,11 @@ bool native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index) {
     return false;
   }
 
-  return wait_set->clients[index] != NULL;
+  bool result = wait_set->clients[index] != NULL;
+  return result ? 1 : 0;
 }
 
-bool native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index) {
+int32_t native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
 
   if (index >= wait_set->size_of_services)
@@ -301,10 +306,11 @@ bool native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index) {
     return false;
   }
 
-  return wait_set->services[index] != NULL;
+  bool result = wait_set->services[index] != NULL;
+  return result ? 1 : 0;
 }
 
-bool native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t index) {
+int32_t native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t index) {
   rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
 
   if (index >= wait_set->size_of_guard_conditions)
@@ -312,29 +318,42 @@ bool native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t in
     return false;
   }
 
-  return wait_set->guard_conditions[index] != NULL;
+  bool result = wait_set->guard_conditions[index] != NULL;
+  return result ? 1 : 0;
 }
 
 int32_t native_rcl_action_client_wait_set_get_entities_ready(
     void *wait_set_handle,
     void *action_client_handle,
-    bool *is_feedback_ready,
-    bool *is_status_ready,
-    bool *is_goal_response_ready,
-    bool *is_cancel_response_ready,
-    bool *is_result_response_ready)
+    int32_t *is_feedback_ready,
+    int32_t *is_status_ready,
+    int32_t *is_goal_response_ready,
+    int32_t *is_cancel_response_ready,
+    int32_t *is_result_response_ready)
 {
     rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
     rcl_action_client_t *action_client = (rcl_action_client_t *)action_client_handle;
 
+    bool is_feedback_ready_as_bool;
+    bool is_status_ready_as_bool;
+    bool is_goal_response_ready_as_bool;
+    bool is_cancel_response_ready_as_bool;
+    bool is_result_response_ready_as_bool;
+
     rcl_ret_t ret = rcl_action_client_wait_set_get_entities_ready(
         wait_set,
         action_client,
-        is_feedback_ready,
-        is_status_ready,
-        is_goal_response_ready,
-        is_cancel_response_ready,
-        is_result_response_ready);
+        &is_feedback_ready_as_bool,
+        &is_status_ready_as_bool,
+        &is_goal_response_ready_as_bool,
+        &is_cancel_response_ready_as_bool,
+        &is_result_response_ready_as_bool);
+
+    *is_feedback_ready = is_feedback_ready_as_bool ? 1 : 0;
+    *is_status_ready = is_status_ready_as_bool ? 1 : 0;
+    *is_goal_response_ready = is_goal_response_ready_as_bool ? 1 : 0;
+    *is_cancel_response_ready = is_cancel_response_ready_as_bool ? 1 : 0;
+    *is_result_response_ready = is_result_response_ready_as_bool ? 1 : 0;
 
     return ret;
 }
@@ -342,21 +361,31 @@ int32_t native_rcl_action_client_wait_set_get_entities_ready(
 int32_t native_rcl_action_server_wait_set_get_entities_ready(
     void *wait_set_handle,
     void *action_server_handle,
-    bool *is_goal_request_ready,
-    bool *is_cancel_request_ready,
-    bool *is_result_request_ready,
-    bool *is_goal_expired)
+    int32_t *is_goal_request_ready,
+    int32_t *is_cancel_request_ready,
+    int32_t *is_result_request_ready,
+    int32_t *is_goal_expired)
 {
     rcl_wait_set_t *wait_set = (rcl_wait_set_t *)wait_set_handle;
     rcl_action_server_t *action_server = (rcl_action_server_t *)action_server_handle;
 
+    bool is_goal_request_ready_as_bool;
+    bool is_cancel_request_ready_as_bool;
+    bool is_result_request_ready_as_bool;
+    bool is_goal_expired_as_bool;
+
     rcl_ret_t ret = rcl_action_server_wait_set_get_entities_ready(
         wait_set,
         action_server,
-        is_goal_request_ready,
-        is_cancel_request_ready,
-        is_result_request_ready,
-        is_goal_expired);
+        &is_goal_request_ready_as_bool,
+        &is_cancel_request_ready_as_bool,
+        &is_result_request_ready_as_bool,
+        &is_goal_expired_as_bool);
+
+    *is_goal_request_ready = is_goal_request_ready_as_bool ? 1 : 0;
+    *is_cancel_request_ready = is_cancel_request_ready_as_bool ? 1 : 0;
+    *is_result_request_ready = is_result_request_ready_as_bool ? 1 : 0;
+    *is_goal_expired = is_goal_expired_as_bool ? 1 : 0;
 
     return ret;
 }
@@ -626,10 +655,11 @@ int32_t native_rcl_action_expire_goals(void *action_server_handle, void *goal_in
   return ret;
 }
 
-bool native_rcl_action_goal_handle_is_active(void *action_goal_handle_handle) {
+int32_t native_rcl_action_goal_handle_is_active(void *action_goal_handle_handle) {
   rcl_action_goal_handle_t *goal_handle = (rcl_action_goal_handle_t *)action_goal_handle_handle;
 
-  return rcl_action_goal_handle_is_active(goal_handle);
+  bool result = rcl_action_goal_handle_is_active(goal_handle);
+  return result ? 1 : 0;
 }
 
 int32_t native_rcl_action_goal_handle_get_status(void *action_goal_handle_handle, int8_t *status) {

--- a/rcldotnet/rcldotnet.h
+++ b/rcldotnet/rcldotnet.h
@@ -32,7 +32,7 @@ RCLDOTNET_EXPORT
 void RCLDOTNET_CDECL native_rcl_reset_error(void);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_ok();
+int32_t RCLDOTNET_CDECL native_rcl_ok();
 
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_create_node_handle(void **, const char *, const char *);
@@ -102,35 +102,35 @@ RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_wait(void *, int64_t);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index);
+int32_t RCLDOTNET_CDECL native_rcl_wait_set_subscription_ready(void *wait_set_handle, int32_t index);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index);
+int32_t RCLDOTNET_CDECL native_rcl_wait_set_client_ready(void *wait_set_handle, int32_t index);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index);
+int32_t RCLDOTNET_CDECL native_rcl_wait_set_service_ready(void *wait_set_handle, int32_t index);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t index);
+int32_t RCLDOTNET_CDECL native_rcl_wait_set_guard_condition_ready(void *wait_set_handle, int32_t index);
 
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_action_client_wait_set_get_entities_ready(
     void *wait_set_handle,
     void *action_client_handle,
-    bool *is_feedback_ready,
-    bool *is_status_ready,
-    bool *is_goal_response_ready,
-    bool *is_cancel_response_ready,
-    bool *is_result_response_ready);
+    int32_t *is_feedback_ready,
+    int32_t *is_status_ready,
+    int32_t *is_goal_response_ready,
+    int32_t *is_cancel_response_ready,
+    int32_t *is_result_response_ready);
 
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_action_server_wait_set_get_entities_ready(
     void *wait_set_handle,
     void *action_server_handle,
-    bool *is_goal_request_ready,
-    bool *is_cancel_request_ready,
-    bool *is_result_request_ready,
-    bool *is_goal_expired);
+    int32_t *is_goal_request_ready,
+    int32_t *is_cancel_request_ready,
+    int32_t *is_result_request_ready,
+    int32_t *is_goal_expired);
 
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_take(void *, void *);
@@ -211,7 +211,7 @@ RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_action_expire_goals(void *action_server_handle, void *goal_info_handle, int32_t *num_expired);
 
 RCLDOTNET_EXPORT
-bool RCLDOTNET_CDECL native_rcl_action_goal_handle_is_active(void *action_goal_handle_handle);
+int32_t RCLDOTNET_CDECL native_rcl_action_goal_handle_is_active(void *action_goal_handle_handle);
 
 RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_action_goal_handle_get_status(void *action_goal_handle_handle, int8_t *status);

--- a/rcldotnet/rcldotnet_action_client.c
+++ b/rcldotnet/rcldotnet_action_client.c
@@ -49,10 +49,13 @@ int32_t native_rcl_action_send_cancel_request(void *action_client_handle, void *
   return ret;
 }
 
-int32_t native_rcl_action_server_is_available(void *node_handle, void *client_handle, bool *is_available) {
+int32_t native_rcl_action_server_is_available(void *node_handle, void *client_handle, int32_t *is_available) {
   rcl_node_t * node = (rcl_node_t *)node_handle;
   rcl_action_client_t * client = (rcl_action_client_t *)client_handle;
 
-  rcl_ret_t ret = rcl_action_server_is_available(node, client, is_available);
+  bool is_available_as_bool;
+  rcl_ret_t ret = rcl_action_server_is_available(node, client, &is_available_as_bool);
+  *is_available = is_available_as_bool ? 1 : 0;
+
   return ret;
 }

--- a/rcldotnet/rcldotnet_action_client.h
+++ b/rcldotnet/rcldotnet_action_client.h
@@ -27,6 +27,6 @@ RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_action_send_cancel_request(void *action_client_handle, void *cancel_request_handle, int64_t *sequence_number);
 
 RCLDOTNET_EXPORT
-int32_t RCLDOTNET_CDECL native_rcl_action_server_is_available(void *node_handle, void *action_client_handle, bool *is_available);
+int32_t RCLDOTNET_CDECL native_rcl_action_server_is_available(void *node_handle, void *action_client_handle, int32_t *is_available);
 
 #endif // RCLDOTNET_CLIENT_H

--- a/rcldotnet/rcldotnet_client.c
+++ b/rcldotnet/rcldotnet_client.c
@@ -34,10 +34,13 @@ int32_t native_rcl_send_request(void *client_handle, void *request_handle, int64
   return ret;
 }
 
-int32_t native_rcl_service_server_is_available(void *node_handle, void *client_handle, bool *is_available) {
+int32_t native_rcl_service_server_is_available(void *node_handle, void *client_handle, int32_t *is_available) {
   rcl_node_t * node = (rcl_node_t *)node_handle;
   rcl_client_t * client = (rcl_client_t *)client_handle;
 
-  rcl_ret_t ret = rcl_service_server_is_available(node, client, is_available);
+  bool is_available_as_bool;
+  rcl_ret_t ret = rcl_service_server_is_available(node, client, &is_available_as_bool);
+  *is_available = is_available_as_bool ? 1 : 0;
+
   return ret;
 }

--- a/rcldotnet/rcldotnet_client.h
+++ b/rcldotnet/rcldotnet_client.h
@@ -21,6 +21,6 @@ RCLDOTNET_EXPORT
 int32_t RCLDOTNET_CDECL native_rcl_send_request(void *client_handle, void *request_handle, int64_t *sequence_number);
 
 RCLDOTNET_EXPORT
-int32_t RCLDOTNET_CDECL native_rcl_service_server_is_available(void *node_handle, void *client_handle, bool *is_available);
+int32_t RCLDOTNET_CDECL native_rcl_service_server_is_available(void *node_handle, void *client_handle, int32_t *is_available);
 
 #endif // RCLDOTNET_CLIENT_H

--- a/rosidl_generator_dotnet/resource/msg.h.em
+++ b/rosidl_generator_dotnet/resource/msg.h.em
@@ -7,6 +7,7 @@ from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import NamespacedType
+from rosidl_parser.definition import BOOLEAN_TYPE
 from rosidl_generator_dotnet import msg_type_to_c
 
 type_name = message.structure.namespaced_type.name
@@ -62,7 +63,13 @@ int32_t @(msg_prefix)_CDECL @(msg_typename)__getsize_field_@(member.name)_messag
 bool @(msg_prefix)_CDECL @(msg_typename)__init_sequence_field_@(member.name)_message(void *, int32_t);
 
 @[        end if]@
-@[        if isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == BOOLEAN_TYPE]@
+@# Special handling for marshaling bool as int32_t
+@(msg_prefix)_EXPORT
+void @(msg_typename)__write_field_@(member.name)(void *, int32_t /* bool */);
+@(msg_prefix)_EXPORT
+int32_t /* bool */ @(msg_prefix)_CDECL @(msg_typename)__read_field_@(member.name)(void *);
+@[        elif isinstance(member.type.value_type, BasicType) or isinstance(member.type.value_type, AbstractString)]@
 @(msg_prefix)_EXPORT
 void @(msg_typename)__write_field_@(member.name)(void *, @(msg_type_to_c(member.type.value_type)));
 @(msg_prefix)_EXPORT
@@ -71,6 +78,13 @@ void @(msg_typename)__write_field_@(member.name)(void *, @(msg_type_to_c(member.
 
 @[    elif isinstance(member.type, AbstractWString)]@
 // TODO: Unicode types are not supported
+@[    elif isinstance(member.type, BasicType) and member.type.typename == BOOLEAN_TYPE]@
+@# Special handling for marshaling bool as int32_t
+@(msg_prefix)_EXPORT
+int32_t /* bool */ @(msg_prefix)_CDECL @(msg_typename)__read_field_@(member.name)(void *);
+
+@(msg_prefix)_EXPORT
+void @(msg_typename)__write_field_@(member.name)(void *, int32_t /* bool */);
 @[    elif isinstance(member.type, BasicType) or isinstance(member.type, AbstractString)]@
 @(msg_prefix)_EXPORT
 @(msg_type_to_c(member.type)) @(msg_prefix)_CDECL @(msg_typename)__read_field_@(member.name)(void *);


### PR DESCRIPTION
This fixes Issues with bools that where interpreted wrong in release builds.

See https://www.mono-project.com/docs/advanced/pinvoke/#boolean-membersfor more information on marshalling bools.

Took the following path:
- Use `int` on C# side and `int32_t` on the c side instead of bool for the libary code to make this as explicit as it gets and avoid `bool` entierly.
- Use `bool` on C# side and `int32_t` on the c side in the messages code. This avoids having to ad special cases to the C# template for the code generation. As `bool`s in C# pInvokes get marshalled as 32 bit integer by default there is no need to change the code for `bool` fields.

This should be merged with fast forward (without merge commit) to keep the history for the upstream pr clean and identical to the internal-main one.