### PR TITLE
arm64 support - set c# target framework to netcoreapp6.0

### DIFF
--- a/rcldotnet_examples/CMakeLists.txt
+++ b/rcldotnet_examples/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(rcldotnet REQUIRED)
 
 find_package(dotnet_cmake_module REQUIRED)
 
-set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
+set(CSHARP_TARGET_FRAMEWORK "netcoreapp6.0")
 find_package(DotNETExtra REQUIRED)
 
 set(_assemblies_dep_dlls


### PR DESCRIPTION
netcoreapp2.0 does not seem to support arm64